### PR TITLE
Runner config folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,7 @@ ssl_certificate: ''
 
 ### ---- GITLAB RUNNER CONFIGURATION VARIABLES --- ###
 
-gitlab_runner_conf_path: /etc/gitlab-runner/
-gitlab_runner_conf: config.toml
+gitlab_runner_conf_file: config.toml
 
 # Runner tags
 gitlab_runner_tags: []
@@ -37,7 +36,7 @@ gitlab_runner_name: 'runner_test'
 # CI URL
 gitlab_runner_coordinator_url: 'https://{{ gitlab_fqdn }}/ci'
 # runner token
-gitlab_runner_token: 'FOOFOOBAR'
+gitlab_runner_token: ''
 # select how a project should be built, see next section
 # run build locally, default
 #   - shell
@@ -71,8 +70,7 @@ gitlab_runner_executor: 'docker'
 # don't limit
 gitlab_runner_limit: '0'
 # file containing the certificates to verify the peer when using HTTPS
-gitlab_runner_tls_path: "/etc/gitlab/certs"
-gitlab_runner_tls_ca_file: "{{ gitlab_runner_tls_path }}/{{ gitlab_fqdn }}.crt"
+gitlab_runner_tls_ca_file: ''
 # whether to verify the TLS certificate when using HTTPS, default: false
 gitlab_runner_tls_skip_verify: false
 # the name of shell to generate the script (default value is platform dependent)
@@ -91,7 +89,6 @@ gitlab_runner_environment:
 gitlab_runner_disable_verbose: false
 # set maximum build log size in kilobytes, by default set to 4096 (4MB)
 gitlab_runner_output_limit: ''
-
 
 
 ##------ [runners.docker] ------##

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -18,18 +18,25 @@
 
 - name: GitlabRunner | Create SSL configuration folder.
   file:
-    path="{{ gitlab_runner_tls_path }}"
+    path="{{ gitlab_runner_conf_path }}/certs"
     state=directory
     owner={{ gitlab_runner_user }}
     group={{ gitlab_runner_user }}
     mode=0700
   when: "'{{ ssl_certificate }}' != '' "
 
+- name: GitlabRunner | Default TLS cert path
+  set_fact:
+    gitlab_runner_tls_ca_file: "{{ gitlab_runner_conf_path }}/certs/{{ gitlab_fqdn }}.crt"
+  when: "'{{ gitlab_runner_tls_ca_file }}' == ''"
+
 # Copy gitlab/ci SSL certificate
 - name: GitlabRunner | Deploy self-signed certificate.
   template:
     src={{ item.src }}
     dest={{ item.dest }}
+    owner={{ gitlab_runner_user }}
+    group={{ gitlab_runner_user }}
     mode=0644
   with_items:
     - src:  "ssl_certificate.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,15 @@
   tags:
     - checks
 
+- name: GitlabRunner | Initialize def. conf. path based on User
+  set_fact:
+    gitlab_runner_conf_path: /etc/gitlab-runner
+
+- name: GitlabRunner | Define def. conf. path based on User
+  set_fact:
+    gitlab_runner_conf_path: /home/{{ gitlab_runner_user }}/.gitlab-runner
+  when: "'{{ gitlab_runner_user }}' != 'root'"
+
 - include: pre-install.yml
   tags:
     - pre-install


### PR DESCRIPTION
Define gitlab runner configuration folder, based on the user that will run gitlab.
for non *nix systems, there is the option to overwrite the variable `gitlab_runner_tls_ca_file`.
- `/etc/gitlab-runner/certs/hostname.crt` on *nix systems when gitlab-runner is executed as root.
- `~/.gitlab-runner/certs/hostname.crt` on *nix systems when gitlab-runner is executed as non-root,
- `./certs/hostname.crt` on other systems.

If address of your server is: `https://my.gitlab.server.com:8443/`.
Create the certificate file at: `/etc/gitlab-runner/certs/my.gitlab.server.com.crt`. 
